### PR TITLE
Use crate type `cdylib`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license      = "GPL-3.0"
 
 [lib]
 name         = "cryptobox"
-crate-type   = ["dylib"]
+crate-type   = ["cdylib"]
 
 [dependencies]
 libc = ">= 0.1.12"


### PR DESCRIPTION
Rust 1.10 introduced `cdylib` (cf. RFC 1510) as a new crate type
targeted for embedded rust libraries. It omits rust metadata and only
exports public extern functions which should reduce our artifact size.