### PR TITLE
Fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,6 @@ name         = "cryptobox"
 crate-type   = ["cdylib"]
 
 [dependencies]
-libc = ">= 0.1.12"
-
-[dependencies.proteus]
-git = "https://github.com/wireapp/proteus"
-branch = "develop"
-
-[dependencies.cryptobox]
-git = "https://github.com/wireapp/cryptobox"
-branch = "develop"
+cryptobox = { git = "https://github.com/wireapp/cryptobox", branch = "develop" }
+libc      = ">= 0.1.12"
+proteus   = { git = "https://github.com/wireapp/proteus", branch = "develop" }

--- a/src/cbox.h
+++ b/src/cbox.h
@@ -105,7 +105,10 @@ typedef enum {
     // Failure to initialise proteus/libsodium. Client code should not
     // proceed after encountering this error (which can only happen
     // when opening a cbox).
-    CBOX_INIT_ERROR              = 16
+    CBOX_INIT_ERROR              = 16,
+
+    // Unsafe key material was used.
+    CBOX_DEGENERATED_KEY         = 17
 
 } CBoxResult;
 

--- a/src/cbox.h
+++ b/src/cbox.h
@@ -96,6 +96,10 @@ typedef enum {
 
     // An unknown critical error was encountered which prevented the
     // computation from succeeding.
+    //
+    // Nb. If a `CBOX_PANIC` has been returned from an API operation,
+    // any further use of the `CBox` or any `CBoxSession` results in
+    // undefined behaviour!
     CBOX_PANIC                   = 15
 } CBoxResult;
 

--- a/src/cbox.h
+++ b/src/cbox.h
@@ -100,7 +100,13 @@ typedef enum {
     // Nb. If a `CBOX_PANIC` has been returned from an API operation,
     // any further use of the `CBox` or any `CBoxSession` results in
     // undefined behaviour!
-    CBOX_PANIC                   = 15
+    CBOX_PANIC                   = 15,
+
+    // Failure to initialise proteus/libsodium. Client code should not
+    // proceed after encountering this error (which can only happen
+    // when opening a cbox).
+    CBOX_INIT_ERROR              = 16
+
 } CBoxResult;
 
 // CBoxIdentityMode /////////////////////////////////////////////////////////

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use cryptobox::store::file::FileStore;
 use libc::{c_char, c_ushort, size_t, uint8_t, uint16_t};
 use proteus::{DecodeError, EncodeError};
 use proteus::keys::{self, PreKeyId, PreKeyBundle};
-use proteus::session::DecryptError;
+use proteus::session;
 use std::borrow::Cow;
 use std::ffi::CStr;
 use std::fmt;
@@ -355,26 +355,28 @@ pub enum CBoxResult {
     IdentityError         = 13,
     PreKeyNotFound        = 14,
     Panic                 = 15,
-    InitError             = 16
+    InitError             = 16,
+    DegeneratedKey        = 17
 }
 
 impl<S: Store + fmt::Debug> From<CBoxError<S>> for CBoxResult {
     fn from(e: CBoxError<S>) -> CBoxResult {
         let _ = log::error(&e);
         match e {
-            CBoxError::DecryptError(DecryptError::RemoteIdentityChanged) => CBoxResult::RemoteIdentityChanged,
-            CBoxError::DecryptError(DecryptError::InvalidSignature)      => CBoxResult::InvalidSignature,
-            CBoxError::DecryptError(DecryptError::InvalidMessage)        => CBoxResult::InvalidMessage,
-            CBoxError::DecryptError(DecryptError::DuplicateMessage)      => CBoxResult::DuplicateMessage,
-            CBoxError::DecryptError(DecryptError::TooDistantFuture)      => CBoxResult::TooDistantFuture,
-            CBoxError::DecryptError(DecryptError::OutdatedMessage)       => CBoxResult::OutdatedMessage,
-            CBoxError::DecryptError(DecryptError::PreKeyNotFound(_))     => CBoxResult::PreKeyNotFound,
-            CBoxError::DecryptError(DecryptError::PreKeyStoreError(_))   => CBoxResult::StorageError,
-            CBoxError::StorageError(_)                                   => CBoxResult::StorageError,
-            CBoxError::DecodeError(_)                                    => CBoxResult::DecodeError,
-            CBoxError::EncodeError(_)                                    => CBoxResult::EncodeError,
-            CBoxError::IdentityError                                     => CBoxResult::IdentityError,
-            CBoxError::InitError                                         => CBoxResult::InitError
+            CBoxError::ProteusError(session::Error::RemoteIdentityChanged) => CBoxResult::RemoteIdentityChanged,
+            CBoxError::ProteusError(session::Error::InvalidSignature)      => CBoxResult::InvalidSignature,
+            CBoxError::ProteusError(session::Error::InvalidMessage)        => CBoxResult::InvalidMessage,
+            CBoxError::ProteusError(session::Error::DuplicateMessage)      => CBoxResult::DuplicateMessage,
+            CBoxError::ProteusError(session::Error::TooDistantFuture)      => CBoxResult::TooDistantFuture,
+            CBoxError::ProteusError(session::Error::OutdatedMessage)       => CBoxResult::OutdatedMessage,
+            CBoxError::ProteusError(session::Error::PreKeyNotFound(_))     => CBoxResult::PreKeyNotFound,
+            CBoxError::ProteusError(session::Error::PreKeyStoreError(_))   => CBoxResult::StorageError,
+            CBoxError::ProteusError(session::Error::DegeneratedKey)        => CBoxResult::DegeneratedKey,
+            CBoxError::StorageError(_)                                     => CBoxResult::StorageError,
+            CBoxError::DecodeError(_)                                      => CBoxResult::DecodeError,
+            CBoxError::EncodeError(_)                                      => CBoxResult::EncodeError,
+            CBoxError::IdentityError                                       => CBoxResult::IdentityError,
+            CBoxError::InitError                                           => CBoxResult::InitError
         }
     }
 }

--- a/test/main.c
+++ b/test/main.c
@@ -48,11 +48,12 @@ void test_basics(CBox * alice_box, CBox * bob_box) {
     assert(rc == CBOX_SUCCESS);
     rc = cbox_session_save(alice_box, alice);
     assert(rc == CBOX_SUCCESS);
-    uint8_t const hello_bob[] = "Hello Bob!";
+    char const * hello_bob = "Hello Bob!";
+    size_t hello_bob_len = strlen(hello_bob);
     CBoxVec * cipher = NULL;
-    rc = cbox_encrypt(alice, hello_bob, sizeof(hello_bob), &cipher);
+    rc = cbox_encrypt(alice, (uint8_t const *) hello_bob, hello_bob_len, &cipher);
     assert(rc == CBOX_SUCCESS);
-    assert(strncmp((char const *) hello_bob, (char const *) cbox_vec_data(cipher), cbox_vec_len(cipher)) != 0);
+    assert(strncmp(hello_bob, (char const *) cbox_vec_data(cipher), hello_bob_len) != 0);
 
     // Bob
     CBoxSession * bob = NULL;
@@ -61,7 +62,7 @@ void test_basics(CBox * alice_box, CBox * bob_box) {
     assert(rc == CBOX_SUCCESS);
     cbox_session_save(bob_box, bob);
 
-    assert(strncmp((char const *) hello_bob, (char const *) cbox_vec_data(plain), cbox_vec_len(plain)) == 0);
+    assert(strncmp(hello_bob, (char const *) cbox_vec_data(plain), hello_bob_len) == 0);
 
     // Compare fingerprints
     CBoxVec * local = NULL;


### PR DESCRIPTION
Depends on https://github.com/wireapp/cryptobox/pull/4

Besides updates due to `cryptobox` changes we now check string arguments for trailing `\0` byte and include debug assertions which check for NULL pointers.